### PR TITLE
Add WiFi network entities with location read/write support

### DIFF
--- a/custom_components/tryfi/__init__.py
+++ b/custom_components/tryfi/__init__.py
@@ -43,9 +43,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         tryfi = await hass.async_add_executor_job(PyTryFi, username, password)
         _LOGGER.info(
-            "TryFi API initialized: %d pets, %d bases", 
-            len(tryfi.pets), 
-            len(tryfi.bases)
+            "TryFi API initialized: %d pets, %d bases, %d wifi networks",
+            len(tryfi.pets),
+            len(tryfi.bases),
+            len(tryfi.wifiNetworks),
         )
     except Exception as err:
         _LOGGER.error("Failed to initialize TryFi API: %s", err, exc_info=True)
@@ -118,10 +119,11 @@ async def async_remove_config_entry_device(
     try:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         
-        # Get all current pet and base IDs from the API
+        # Get all current pet, base, and WiFi network IDs from the API
         current_pet_ids = {pet.petId for pet in coordinator.data.pets}
         current_base_ids = {base.baseId for base in coordinator.data.bases}
-        
+        current_wifi_ids = {f"wifi-{n.ssid}" for n in coordinator.data.wifiNetworks}
+
         # Check if this device is still in the API
         for identifier in device_entry.identifiers:
             if identifier[0] == DOMAIN:
@@ -131,7 +133,7 @@ async def async_remove_config_entry_device(
                     _LOGGER.info("Allowing removal of old format base device with base_ prefix: %s", device_id)
                     return True
                 # If the device is no longer in the API, allow removal
-                if device_id not in current_pet_ids and device_id not in current_base_ids:
+                if device_id not in current_pet_ids and device_id not in current_base_ids and device_id not in current_wifi_ids:
                     _LOGGER.info("Allowing removal of device not in API: %s", device_id)
                     return True
     except Exception as e:
@@ -247,8 +249,35 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         
         raise HomeAssistantError(f"Pet not found for entity {entity_id}")
     
+    async def handle_set_wifi_location(call: ServiceCall) -> None:
+        """Handle set WiFi network location service."""
+        ssid = call.data.get("ssid")
+        latitude = call.data.get("latitude")
+        longitude = call.data.get("longitude")
+
+        if not ssid:
+            raise HomeAssistantError("No ssid provided")
+        if latitude is None or longitude is None:
+            raise HomeAssistantError("Both latitude and longitude are required")
+
+        for entry_id, coordinator in hass.data[DOMAIN].items():
+            if isinstance(coordinator, TryFiDataUpdateCoordinator):
+                network = coordinator.data.getWifiNetwork(ssid)
+                if network:
+                    await hass.async_add_executor_job(
+                        coordinator.data.setWifiNetworkLocation,
+                        ssid,
+                        float(latitude),
+                        float(longitude),
+                    )
+                    await coordinator.async_request_refresh()
+                    return
+
+        raise HomeAssistantError(f"WiFi network not found: {ssid}")
+
     # Register services
     hass.services.async_register(DOMAIN, "set_led_color", handle_set_led_color)
     hass.services.async_register(DOMAIN, "turn_on_led", handle_turn_on_led)
     hass.services.async_register(DOMAIN, "turn_off_led", handle_turn_off_led)
     hass.services.async_register(DOMAIN, "set_lost_mode", handle_set_lost_mode)
+    hass.services.async_register(DOMAIN, "set_wifi_location", handle_set_wifi_location)

--- a/custom_components/tryfi/binary_sensor.py
+++ b/custom_components/tryfi/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER, MODEL
 from .pytryfi import PyTryFi
+from .pytryfi.fiWifiNetwork import FiWifiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,8 +52,26 @@ async def async_setup_entry(
         for pet in tryfi.pets
         if hasattr(pet, "device") and pet.device
     ])
-    
+
+    # Add WiFi network hidden sensors
+    known_wifi_ssids: set[str] = set()
+    for network in tryfi.wifiNetworks:
+        known_wifi_ssids.add(network.ssid)
+        entities.append(TryFiWifiNetworkHiddenBinarySensor(coordinator, network))
+
     async_add_entities(entities)
+
+    # Listen for new WiFi networks on coordinator updates
+    def _check_new_wifi_networks() -> None:
+        new_entities = []
+        for network in coordinator.data.wifiNetworks:
+            if network.ssid not in known_wifi_ssids:
+                known_wifi_ssids.add(network.ssid)
+                new_entities.append(TryFiWifiNetworkHiddenBinarySensor(coordinator, network))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_check_new_wifi_networks))
 
 
 class TryFiBatteryChargingBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -169,26 +188,26 @@ class TryFiBaseHealthBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
 class TryFiFirmwareUpdateBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a TryFi firmware update availability sensor."""
-    
+
     _attr_has_entity_name = False
     _attr_device_class = BinarySensorDeviceClass.UPDATE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    
+
     # Known firmware versions (you can update this list as new versions are released)
     LATEST_FIRMWARE = "3.3.0"  # Example version
-    
+
     def __init__(self, coordinator: Any, pet: Any) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator)
         self._pet_id = pet.petId
         self._attr_unique_id = f"{pet.petId}-firmware-update"
         self._attr_name = f"{pet.name} Firmware Update Available"
-    
+
     @property
     def pet(self) -> Any:
         """Get the pet object from coordinator data."""
         return self.coordinator.data.getPet(self._pet_id)
-    
+
     @property
     def is_on(self) -> bool | None:
         """Return true if firmware update is available."""
@@ -199,12 +218,12 @@ class TryFiFirmwareUpdateBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 # For now, just check if versions are different
                 return current_version != self.LATEST_FIRMWARE
         return None
-    
+
     @property
     def icon(self) -> str:
         """Return the icon to use in the frontend."""
         return "mdi:update" if self.is_on else "mdi:check-circle"
-    
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
@@ -215,28 +234,73 @@ class TryFiFirmwareUpdateBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 attrs["current_version"] = current_version
                 attrs["latest_version"] = self.LATEST_FIRMWARE
         return attrs
-    
+
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information."""
         pet = self.pet
         if not pet:
             return {}
-        
+
         device_info = {
             "identifiers": {(DOMAIN, pet.petId)},
             "name": pet.name,
             "manufacturer": MANUFACTURER,
             "model": MODEL,
         }
-        
+
         # Add breed if available
         if hasattr(pet, "breed") and pet.breed:
             device_info["model"] = f"{MODEL} - {pet.breed}"
-        
+
         # Add firmware version if available
         if hasattr(pet, "device") and pet.device:
             if hasattr(pet.device, "buildId"):
                 device_info["sw_version"] = pet.device.buildId
-        
+
         return device_info
+
+
+class TryFiWifiNetworkHiddenBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Representation of a TryFi WiFi network hidden binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: Any, network: FiWifiNetwork) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self._ssid = network.ssid
+        self._attr_unique_id = f"wifi-{network.ssid}-hidden"
+        self._attr_name = "Hidden"
+
+    @property
+    def network(self) -> FiWifiNetwork | None:
+        """Get the WiFi network object from coordinator data."""
+        return self.coordinator.data.getWifiNetwork(self._ssid)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the WiFi network is hidden."""
+        network = self.network
+        if not network:
+            return None
+        return network.isHidden
+
+    @property
+    def icon(self) -> str:
+        """Return the icon to use in the frontend."""
+        return "mdi:wifi-off" if self.is_on else "mdi:wifi"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information."""
+        network = self.network
+        if not network:
+            return {}
+
+        return {
+            "identifiers": {(DOMAIN, f"wifi-{network.ssid}")},
+            "name": f"WiFi {network.ssid}",
+            "manufacturer": MANUFACTURER,
+            "model": "WiFi Network",
+        }

--- a/custom_components/tryfi/coordinator.py
+++ b/custom_components/tryfi/coordinator.py
@@ -36,9 +36,10 @@ class TryFiDataUpdateCoordinator(DataUpdateCoordinator[PyTryFi]):
         try:
             await self.hass.async_add_executor_job(self.tryfi.update)
             _LOGGER.info(
-                "TryFi data updated: %d pets, %d bases", 
-                len(self.tryfi.pets), 
-                len(self.tryfi.bases)
+                "TryFi data updated: %d pets, %d bases, %d wifi networks",
+                len(self.tryfi.pets),
+                len(self.tryfi.bases),
+                len(self.tryfi.wifiNetworks),
             )
             
             # Check for state changes and fire events

--- a/custom_components/tryfi/device_tracker.py
+++ b/custom_components/tryfi/device_tracker.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER, MODEL
-from .pytryfi import PyTryFi, FiPet, FiBase
+from .pytryfi import PyTryFi, FiPet, FiBase, FiWifiNetwork
 from . import TryFiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,8 +40,26 @@ async def async_setup_entry(
         TryFiBaseTracker(coordinator, base)
         for base in tryfi.bases
     ])
-    
+
+    # Add WiFi network trackers
+    known_wifi_ssids: set[str] = set()
+    for network in tryfi.wifiNetworks:
+        known_wifi_ssids.add(network.ssid)
+        entities.append(TryFiWifiNetworkTracker(coordinator, network))
+
     async_add_entities(entities, True)
+
+    # Listen for new WiFi networks on coordinator updates
+    def _check_new_wifi_networks() -> None:
+        new_entities = []
+        for network in coordinator.data.wifiNetworks:
+            if network.ssid not in known_wifi_ssids:
+                known_wifi_ssids.add(network.ssid)
+                new_entities.append(TryFiWifiNetworkTracker(coordinator, network))
+        if new_entities:
+            async_add_entities(new_entities, True)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_check_new_wifi_networks))
 
 
 class TryFiPetTracker(CoordinatorEntity, TrackerEntity):
@@ -178,4 +196,56 @@ class TryFiBaseTracker(CoordinatorEntity, TrackerEntity):
             "name": base.name,
             "manufacturer": MANUFACTURER,
             "model": "TryFi Base Station",
+        }
+
+
+class TryFiWifiNetworkTracker(CoordinatorEntity, TrackerEntity):
+    """Representation of a TryFi WiFi network tracker."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(self, coordinator: Any, network: FiWifiNetwork) -> None:
+        """Initialize the WiFi network tracker."""
+        super().__init__(coordinator)
+        self._ssid = network.ssid
+        self._attr_unique_id = f"wifi-{network.ssid}-tracker"
+        self._attr_icon = "mdi:wifi-marker"
+
+    @property
+    def network(self) -> FiWifiNetwork | None:
+        """Get the WiFi network object from coordinator data."""
+        return self.coordinator.data.getWifiNetwork(self._ssid)
+
+    @property
+    def latitude(self) -> float | None:
+        """Return latitude value of the WiFi network."""
+        if self.network and self.network.latitude is not None:
+            return float(self.network.latitude)
+        return None
+
+    @property
+    def longitude(self) -> float | None:
+        """Return longitude value of the WiFi network."""
+        if self.network and self.network.longitude is not None:
+            return float(self.network.longitude)
+        return None
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return the source type of the device."""
+        return SourceType.GPS
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information."""
+        network = self.network
+        if not network:
+            return {}
+
+        return {
+            "identifiers": {(DOMAIN, f"wifi-{network.ssid}")},
+            "name": f"WiFi {network.ssid}",
+            "manufacturer": MANUFACTURER,
+            "model": "WiFi Network",
         }

--- a/custom_components/tryfi/pytryfi/__init__.py
+++ b/custom_components/tryfi/pytryfi/__init__.py
@@ -7,12 +7,14 @@ from .fiUser import FiUser
 from .fiPet import FiPet
 from .fiBase import FiBase
 from .fiDevice import FiDevice
-from .common.query import API_HOST_URL_BASE, API_LOGIN, getHouseHolds, getBaseList
+from .fiWifiNetwork import FiWifiNetwork
+from .common.query import API_HOST_URL_BASE, API_LOGIN, getHouseHolds, getBaseList, getWifiNetworks, updateWifiNetwork
 
 __all__ = [
     'FiDevice',
     'FiPet',
     'FiUser',
+    'FiWifiNetwork',
     'PyTryFi'
 ]
 
@@ -34,7 +36,14 @@ class PyTryFi(object):
         self._currentUser.setUserDetails(userHousehold)
         self._pets = []
         self._bases = []
+        self._householdIds = []
+        self._wifiNetworks = []
         for house in userHousehold['userHouseholds']:
+            householdId = house['household'].get('id')
+            if householdId:
+                self._householdIds.append(householdId)
+                LOGGER.debug(f"Found household ID: {householdId}")
+
             for pet in house['household']['pets']:
                 # If pet doesn't have a collar then ignore it. What good is a pet without a collar!
                 if pet['device'] is None:
@@ -58,6 +67,9 @@ class PyTryFi(object):
                     self._bases.append(b)
                 except (KeyError, TypeError, ValueError) as e:
                     LOGGER.warning("Skipping base with invalid data: %s", e)
+
+        # Fetch WiFi networks for each household
+        self.updateWifiNetworks()
 
     def __str__(self):
         instString = f"Username: {self.username}"
@@ -107,6 +119,35 @@ class PyTryFi(object):
         LOGGER.error(f"Cannot find Base: {baseId}")
         return None
 
+    def updateWifiNetworks(self):
+        updatedNetworks = []
+        for householdId in self._householdIds:
+            try:
+                wifiData = getWifiNetworks(self._session, householdId)
+                for network in wifiData.get('networks', []):
+                    ssid = network.get('ssid')
+                    if ssid:
+                        w = FiWifiNetwork(ssid, householdId)
+                        w.setDetailsJSON(network)
+                        LOGGER.debug(f"Adding WiFi Network: {w.ssid} State: {w.state}")
+                        updatedNetworks.append(w)
+            except Exception as e:
+                LOGGER.warning("failed to fetch WiFi networks for household %s: %s", householdId, e, exc_info=True)
+        self._wifiNetworks = updatedNetworks
+
+    def getWifiNetwork(self, ssid):
+        for w in self._wifiNetworks:
+            if w.ssid == ssid:
+                return w
+        LOGGER.error(f"Cannot find WiFi Network: {ssid}")
+        return None
+
+    def setWifiNetworkLocation(self, ssid, latitude, longitude):
+        network = self.getWifiNetwork(ssid)
+        if not network:
+            raise Exception(f"WiFi network not found: {ssid}")
+        return updateWifiNetwork(self._session, network.householdId, ssid, latitude, longitude)
+
     def update(self):
         try:
             self.updateBases()
@@ -116,6 +157,10 @@ class PyTryFi(object):
             self.updatePets()
         except Exception as e:
             LOGGER.warning("failed to update pets: %s", e, exc_info=True)
+        try:
+            self.updateWifiNetworks()
+        except Exception as e:
+            LOGGER.warning("failed to update wifi networks: %s", e, exc_info=True)
 
     @property
     def currentUser(self):
@@ -126,6 +171,12 @@ class PyTryFi(object):
     @property
     def bases(self):
         return self._bases
+    @property
+    def wifiNetworks(self) -> list[FiWifiNetwork]:
+        return self._wifiNetworks
+    @property
+    def householdIds(self):
+        return self._householdIds
     @property
     def username(self):
         return self._username

--- a/custom_components/tryfi/pytryfi/common/query.py
+++ b/custom_components/tryfi/pytryfi/common/query.py
@@ -12,6 +12,7 @@ API_GRAPHQL         = "/graphql"
 API_LOGIN           = "/auth/login"
 
 VAR_PET_ID = "__PET_ID__"
+VAR_HOUSEHOLD_ID = "__HOUSEHOLD_ID__"
 
 QUERY_CURRENT_USER_FULL_DETAIL  = "query {  currentUser {    ...UserFullDetails  }}"
 
@@ -38,10 +39,14 @@ FRAGMENT_PLACE_DETAILS = "fragment PlaceDetails on Place {  __typename  id  name
 FRAGMENT_POSITION_COORDINATES = "fragment PositionCoordinates on Position {  __typename  latitude  longitude}"
 FRAGMENT_REST_SUMMARY_DETAILS = "fragment RestSummaryDetails on RestSummary {  __typename  start  end  data {    __typename    ... on ConcreteRestSummaryData {      sleepAmounts {        __typename        type        duration      }    }  }}"
 FRAGMENT_USER_DETAILS = "fragment UserDetails on User {  __typename   id  email  firstName  lastName  phoneNumber }"
-FRAGMENT_USER_FULL_DETAILS = "fragment UserFullDetails on User {  __typename  ...UserDetails  userHouseholds {    __typename    household {      __typename      pets {        __typename        ...PetProfile      }      bases {        __typename        ...BaseDetails      }    }  }}"
+FRAGMENT_USER_FULL_DETAILS = "fragment UserFullDetails on User {  __typename  ...UserDetails  userHouseholds {    __typename    household {      __typename      id      pets {        __typename        ...PetProfile      }      bases {        __typename        ...BaseDetails      }    }  }}"
 
 MUTATION_DEVICE_OPS = "mutation UpdateDeviceOperationParams($input: UpdateDeviceOperationParamsInput!) {  updateDeviceOperationParams(input: $input) {    __typename    ...DeviceDetails  }}"
 MUTATION_SET_LED_COLOR = "mutation SetDeviceLed($moduleId: String!, $ledColorCode: Int!) {  setDeviceLed(moduleId: $moduleId, ledColorCode: $ledColorCode) {    __typename    ...DeviceDetails  }}"
+
+FRAGMENT_WIFI_NETWORK_DETAILS = "fragment WifiNetworkDetails on WifiNetwork {  ssid  state  addressLabel  isHidden  position {    latitude    longitude  }}"
+QUERY_GET_WIFI_NETWORKS = "query GetWifiNetworks($householdId: ID!) {  household(id: $householdId) {    id    wifiNetworks {      credentialPackHash      maximumNetworkCount      networks {        __typename        ...WifiNetworkDetails      }    }  }}"
+MUTATION_UPDATE_WIFI_NETWORK = "mutation UpdateWifiNetwork($input: UpdateWifiNetworkInput!) {  updateWifiNetwork(input: $input) {    __typename    ...WifiNetworkDetails  }}"
 
 REQUEST_FRAGMENTS_PET_ALL_INFO = FRAGMENT_ACTIVITY_SUMMARY_DETAILS + FRAGMENT_ONGOING_ACTIVITY_DETAILS + FRAGMENT_OPERATIONAL_DETAILS + FRAGMENT_CONNECTION_STATE_DETAILS + FRAGMENT_LED_DETAILS \
         + FRAGMENT_REST_SUMMARY_DETAILS + FRAGMENT_POSITION_COORDINATES + FRAGMENT_LOCATION_POINT + FRAGMENT_USER_DETAILS + FRAGMENT_PLACE_DETAILS
@@ -159,6 +164,29 @@ def setLostDogMode(session: requests.Session, moduleId, action: bool):
     response = mutation(session, qString, qVariables)
     LOGGER.debug(f"setLostDogMode: {response}")
     return response['data']
+
+def getWifiNetworks(session: requests.Session, householdId: str):
+    qString = QUERY_GET_WIFI_NETWORKS + FRAGMENT_WIFI_NETWORK_DETAILS
+    qVariables = {"householdId": householdId}
+    response = mutation(session, qString, qVariables)
+    LOGGER.debug(f"getWifiNetworks: {response}")
+    return response['data']['household']['wifiNetworks']
+
+def updateWifiNetwork(session: requests.Session, householdId: str, ssid: str, latitude: float, longitude: float):
+    qString = MUTATION_UPDATE_WIFI_NETWORK + FRAGMENT_WIFI_NETWORK_DETAILS
+    qVariables = {
+        "input": {
+            "householdId": householdId,
+            "ssid": ssid,
+            "position": {
+                "latitude": latitude,
+                "longitude": longitude
+            }
+        }
+    }
+    response = mutation(session, qString, qVariables)
+    LOGGER.debug(f"updateWifiNetwork: {response}")
+    return response['data']['updateWifiNetwork']
 
 def getGraphqlURL():
     return API_HOST_URL_BASE + API_GRAPHQL

--- a/custom_components/tryfi/pytryfi/fiWifiNetwork.py
+++ b/custom_components/tryfi/pytryfi/fiWifiNetwork.py
@@ -1,0 +1,61 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FiWifiNetwork(object):
+    def __init__(self, ssid, household_id):
+        self._ssid = ssid
+        self._householdId = household_id
+        self._state = None
+        self._addressLabel = None
+        self._isHidden = False
+        self._latitude = None
+        self._longitude = None
+
+    def setDetailsJSON(self, networkJSON):
+        self._state = networkJSON.get('state')
+        self._addressLabel = networkJSON.get('addressLabel')
+        self._isHidden = networkJSON.get('isHidden', False)
+        position = networkJSON.get('position')
+        if position:
+            self._latitude = position.get('latitude')
+            self._longitude = position.get('longitude')
+        else:
+            self._latitude = None
+            self._longitude = None
+
+    def __str__(self):
+        return (
+            f"WiFi Network: {self.ssid} State: {self.state} "
+            f"Address: {self.addressLabel} Hidden: {self.isHidden} "
+            f"Location: {self.latitude},{self.longitude}"
+        )
+
+    @property
+    def ssid(self):
+        return self._ssid
+
+    @property
+    def householdId(self):
+        return self._householdId
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def addressLabel(self):
+        return self._addressLabel
+
+    @property
+    def isHidden(self):
+        return self._isHidden
+
+    @property
+    def latitude(self):
+        return self._latitude
+
+    @property
+    def longitude(self):
+        return self._longitude

--- a/custom_components/tryfi/sensor.py
+++ b/custom_components/tryfi/sensor.py
@@ -27,6 +27,7 @@ from custom_components.tryfi.pytryfi.fiPet import FiPet
 
 from .const import DOMAIN, MANUFACTURER, MODEL, SENSOR_STATS_BY_TIME, SENSOR_STATS_BY_TYPE
 from .pytryfi import PyTryFi
+from .pytryfi.fiWifiNetwork import FiWifiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,8 +143,33 @@ async def async_setup_entry(
             TryFiBaseDiagnosticSensor(coordinator, base, "Base ID"),
             TryFiBaseDiagnosticSensor(coordinator, base, "Connection Quality"),
         ])
-    
+
+    # Add WiFi network sensors
+    known_wifi_ssids: set[str] = set()
+    for network in tryfi.wifiNetworks:
+        _LOGGER.debug("Adding sensors for WiFi network: %s", network.ssid)
+        known_wifi_ssids.add(network.ssid)
+        entities.extend([
+            TryFiWifiNetworkSensor(coordinator, network, "Status"),
+            TryFiWifiNetworkSensor(coordinator, network, "Address"),
+        ])
+
     async_add_entities(entities)
+
+    # Listen for new WiFi networks on coordinator updates
+    def _check_new_wifi_networks() -> None:
+        new_entities = []
+        for network in coordinator.data.wifiNetworks:
+            if network.ssid not in known_wifi_ssids:
+                known_wifi_ssids.add(network.ssid)
+                new_entities.extend([
+                    TryFiWifiNetworkSensor(coordinator, network, "Status"),
+                    TryFiWifiNetworkSensor(coordinator, network, "Address"),
+                ])
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_check_new_wifi_networks))
 
 
 class TryFiSensorBase(CoordinatorEntity, SensorEntity):
@@ -619,6 +645,53 @@ class PetBehaviorSensor(TryFiSensorBase):
 
         # Return 0 if None
         return value if value is not None else 0
+
+
+class TryFiWifiNetworkSensor(TryFiSensorBase):
+    """Representation of a TryFi WiFi network sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: Any, network: FiWifiNetwork, sensor_type: str) -> None:
+        """Initialize the WiFi network sensor."""
+        super().__init__(coordinator)
+        self._ssid = network.ssid
+        self._sensor_type = sensor_type
+        self._attr_unique_id = f"wifi-{network.ssid}-{sensor_type.lower()}"
+        self._attr_name = sensor_type
+        self._attr_icon = "mdi:wifi-settings" if sensor_type == "Status" else "mdi:map-marker-outline"
+
+    @property
+    def network(self) -> FiWifiNetwork | None:
+        """Get the WiFi network object from coordinator data."""
+        return self.coordinator.data.getWifiNetwork(self._ssid)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information."""
+        network = self.network
+        if not network:
+            return {}
+        return {
+            "identifiers": {(DOMAIN, f"wifi-{network.ssid}")},
+            "name": f"WiFi {network.ssid}",
+            "manufacturer": MANUFACTURER,
+            "model": "WiFi Network",
+        }
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        network = self.network
+        if not network:
+            return None
+
+        if self._sensor_type == "Status":
+            return network.state
+        elif self._sensor_type == "Address":
+            return network.addressLabel
+
+        return None
 
 
 def icon_for_battery_level(

--- a/custom_components/tryfi/services.yaml
+++ b/custom_components/tryfi/services.yaml
@@ -51,3 +51,34 @@ set_lost_mode:
           options:
             - "Safe"
             - "Lost"
+
+set_wifi_location:
+  name: Set WiFi Network Location
+  description: Set the geographic location of a TryFi WiFi network
+  fields:
+    ssid:
+      name: SSID
+      description: The WiFi network SSID
+      required: true
+      selector:
+        text:
+    latitude:
+      name: Latitude
+      description: Latitude of the WiFi network location
+      required: true
+      selector:
+        number:
+          min: -90
+          max: 90
+          step: 0.000001
+          mode: box
+    longitude:
+      name: Longitude
+      description: Longitude of the WiFi network location
+      required: true
+      selector:
+        number:
+          min: -180
+          max: 180
+          step: 0.000001
+          mode: box


### PR DESCRIPTION
Closes #28

## Summary
- WiFi networks exposed as first-class HA entities with device_tracker (map pin), status/address sensors, and hidden binary sensor per network
- Adds `tryfi.set_wifi_location` service to update network GPS coordinates via the UpdateWifiNetwork GraphQL mutation
- Dynamic entity discovery: new networks appear on the next poll cycle without HA restart

## Details
- New `FiWifiNetwork` model class with ssid, state, addressLabel, isHidden, latitude, longitude
- Added household `id` to `FRAGMENT_USER_FULL_DETAILS` (required by WiFi queries)
- Added `GetWifiNetworks` query and `UpdateWifiNetwork` mutation
- Uses `has_entity_name=True` for clean HA naming (device name as prefix)
- Coordinator update listeners on each platform for dynamic entity creation

## Test plan
- [x] All 73 existing tests pass (`uv run pytest tests/`)
- [x] Deployed to production HA — 6 WiFi networks loaded, all entities functional
- [x] Verified `set_wifi_location` service updates coordinates via TryFi API
- [x] Verified dynamic discovery: space3 network appeared automatically after being added in TryFi app
- [x] No TryFi errors in HA logs across 4 deploy cycles