### PR TITLE
fix parsing bug in series 3+ behavior stats

### DIFF
--- a/custom_components/tryfi/pytryfi/fiPet.py
+++ b/custom_components/tryfi/pytryfi/fiPet.py
@@ -214,13 +214,23 @@ class FiPet(object):
                 LOGGER.warning(f"Could not fetch {period} behavior trends for {self.name}: {e}")
 
     def _parseBehaviorDuration(self, input: str) -> int:
-        # examples: '46min', '1.5hr', '<1min', '10.1'
-        if input.startswith('<'):
+        # examples: '1hr 5min', '46min', '1.5hr', '<1min', '10.1'
+        if input.startswith("<"):
             return 0
-        elif input.endswith('min'):
-            return round(float(input.replace('min', '')))
-        elif input.endswith('hr'):
-            return round(float(input.replace('hr', '')) * 60)
+        elif "hr " in input and "min" in input:
+            parts = input.split()
+            hours = 0
+            minutes = 0
+            for part in parts:
+                if part.endswith("hr"):
+                    hours = float(part.replace("hr", ""))
+                elif part.endswith("min"):
+                    minutes = float(part.replace("min", ""))
+            return round(hours * 60 + minutes)
+        elif input.endswith("min"):
+            return round(float(input.replace("min", "")))
+        elif input.endswith("hr"):
+            return round(float(input.replace("hr", "")) * 60)
         else:
             return round(float(input))
 

--- a/tests/pytryfi/test_pet.py
+++ b/tests/pytryfi/test_pet.py
@@ -7,6 +7,42 @@ import responses
 import urllib.parse
 
 
+class TestParseBehaviorDuration:
+    """Tests for _parseBehaviorDuration method - GitHub Issue #30."""
+
+    def test_parse_minutes_only(self):
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("46min") == 46
+
+    def test_parse_hours_decimal(self):
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("1.5hr") == 90
+
+    def test_parse_less_than_minute(self):
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("<1min") == 0
+
+    def test_parse_decimal_minutes(self):
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("10.1") == 10
+
+    def test_parse_hours_and_minutes_with_space(self):
+        """Test parsing 'Xhr Ymin' format (e.g., '1hr 5min') - GitHub Issue #30."""
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("1hr 5min") == 65
+
+    def test_parse_hours_and_minutes_single_digits(self):
+        """Test parsing 'Xhr Ymin' with single digit values - GitHub Issue #30."""
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("1hr 1min") == 61
+
+    def test_parse_hours_and_minutes_multiple_hours(self):
+        """Test parsing longer durations with multiple hours."""
+        pet = FiPet("test-pet")
+        assert pet._parseBehaviorDuration("6hr 20min") == 380
+        assert pet._parseBehaviorDuration("7hr 28min") == 448
+
+
 @responses.activate
 def test_load_location():
     mock_graphql(


### PR DESCRIPTION
When Tryfi returns metrics like "3hr 5min", the integration would throw an error. This adds handling for it.